### PR TITLE
Replaced bitwise & operator with logical and to fix download script

### DIFF
--- a/codebase/data/download_data.py
+++ b/codebase/data/download_data.py
@@ -15,7 +15,7 @@ $ python download_data.py lite
 """
 
 # Choose which archive to download
-if (len(sys.argv) > 1) & (sys.argv[1]=='lite'):
+if (len(sys.argv) > 1) and (sys.argv[1]=='lite'):
     # Lite archive, only with required inputs for generating and analysing transitions
     archive_file = 'data_lite.zip'
     file_size_mb = 300


### PR DESCRIPTION
Fixing a minor error in the data download script! 

(The bitwise '&' operator was trying to resolve (sys.argv[1]=='lite') when you have no arguments, leading to an index out of range error, which meant you cant do a full archive download) 